### PR TITLE
fix: use validate vim.validate()

### DIFF
--- a/lua/cmp_treesitter/init.lua
+++ b/lua/cmp_treesitter/init.lua
@@ -18,10 +18,8 @@ end
 source.get_keyword_pattern = function(_, params)
   params.option = vim.tbl_deep_extend('keep', params.option, defaults)
   vim.validate({
-    keyword_pattern = {
-      params.option.keyword_pattern, 'string', '`opts.keyword_pattern` must be `string`'
-    },
-    get_bufnrs = {params.option.get_bufnrs, 'function', '`opts.get_bufnrs` must be `function`'}
+    keyword_pattern = { params.option.keyword_pattern, 'string' },
+    get_bufnrs = { params.option.get_bufnrs, 'function' }
   })
   return params.option.keyword_pattern
 end
@@ -29,10 +27,8 @@ end
 source.complete = function(self, params, callback)
   params.option = vim.tbl_deep_extend('keep', params.option, defaults)
   vim.validate({
-    keyword_pattern = {
-      params.option.keyword_pattern, 'string', '`opts.keyword_pattern` must be `string`'
-    },
-    get_bufnrs = {params.option.get_bufnrs, 'function', '`opts.get_bufnrs` must be `function`'}
+    keyword_pattern = { params.option.keyword_pattern, 'string' },
+    get_bufnrs = { params.option.get_bufnrs, 'function' }
   })
 
   local processing = true


### PR DESCRIPTION
1. (arg_value, type_name, optional)
   - arg_value: argument value
   - type_name: string type name, one of: ("table", "t", "string",
     "s", "number", "n", "boolean", "b", "function", "f", "nil",
     "thread", "userdata")
   - optional: (optional) boolean, if true, `nil` is valid
2. (arg_value, fn, msg)
   - arg_value: argument value
   - fn: any function accepting one argument, returns true if and
     only if the argument is valid. Can optionally return an additional
     informative error message as the second returned value.
   - msg: (optional) error string if validation fails