### PR TITLE
Replace get_query with query.get on nvim >= 0.9

### DIFF
--- a/lua/cmp_treesitter/treesitter.lua
+++ b/lua/cmp_treesitter/treesitter.lua
@@ -40,7 +40,9 @@ function treesitter.get_nodes(self)
   end
   local candidates = {}
   for _, tree in pairs(parser:parse()) do
-    local query = vim.treesitter.get_query(parser:lang(), 'highlights')
+    local query = (vim.fn.has('nvim-0.9') == 1) and
+      vim.treesitter.query.get(parser:lang(), 'highlights') or
+      vim.treesitter.get_query(parser:lang(), 'highlights')
 
     for i, node in query:iter_captures(tree:root(), 0) do
       local parent = node:parent()


### PR DESCRIPTION
Neovim 0.9 introduces `nvim.treesitter.query.qet` to replace `.get_query`, which is now due for removal in 0.10, and recent HEAD builds have started emitting deprecation warnings. This PR switches to `.query.get` on 0.9 and above.