### PR TITLE
feat: pass kind to cmp

### DIFF
--- a/lua/cmp_treesitter/init.lua
+++ b/lua/cmp_treesitter/init.lua
@@ -65,7 +65,8 @@ source.complete = function(self, params, callback)
           if #w > 25 then
             w = string.sub(w, 1, 25) .. '…'
           end
-          table.insert(items, { label = w, insertText = word.word, dup = 0 })
+          local camel_cased_kind = word.kind:gsub("%.", " "):gsub("(%w)(%w*)", function(first, rest) return first:upper() .. rest:lower() end):gsub(" ", "")
+          table.insert(items, { label = w, insertText = word.word, dup = 0, cmp = { kind_text = camel_cased_kind }})
         end
       end
     end


### PR DESCRIPTION
This change would pass the symbol kind back to cmp.

It's very basic, and it converts the kinds from `dot.case` to `CamelCase` to overlap with at least some of the LSP kinds, and can also be used for filtering out things like `Comment`s with `entry_filter`.

Could be done better by maintaining a tree-sitter <-> LSP kind mappings, but it's good enough for me, and maybe it helps someone else trying to work around all the completion items being `Text`.

Thanks for making the completion source, it's super fast and the workflow is awesome with LSP replacing the tree-sitter entries when it's done resolving.


https://user-images.githubusercontent.com/59587503/230220658-50cfdb02-7d2d-4d95-8e1d-ef20077361fa.mp4

