### PR TITLE
fix: correctly collect candidates from each buffer

### DIFF
--- a/lua/cmp_treesitter/treesitter.lua
+++ b/lua/cmp_treesitter/treesitter.lua
@@ -34,7 +34,7 @@ function treesitter.get_nodes(self)
     return result
   end
 
-  local ok, parser = pcall(vim.treesitter.get_parser)
+  local ok, parser = pcall(vim.treesitter.get_parser, self.bufnr)
   if not ok then
     return {}
   end
@@ -48,18 +48,18 @@ function treesitter.get_nodes(self)
     end
 
     if query then
-      for i, node in query:iter_captures(tree:root(), 0) do
+      for i, node in query:iter_captures(tree:root(), self.bufnr) do
         local parent = node:parent()
         local grandparent = parent and parent:parent() or nil
-        local word = vim.treesitter.get_node_text(node, 0)
+        local word = vim.treesitter.get_node_text(node, self.bufnr)
         local kind = query.captures[i]
 
         if word and kind ~= 'punctuation.bracket' and kind ~= 'punctuation.delimiter' then
           table.insert(candidates, {
             word = word,
             kind = kind,
-            parent = parent and vim.treesitter.get_node_text(parent, 0) or nil,
-            grandparent = grandparent and vim.treesitter.get_node_text(grandparent, 0) or nil
+            parent = parent and vim.treesitter.get_node_text(parent, self.bufnr) or nil,
+            grandparent = grandparent and vim.treesitter.get_node_text(grandparent, self.bufnr) or nil
           })
         end
       end


### PR DESCRIPTION
The `get_bufnrs` option could be specified to allow candidates from all buffers listed.

```vim
  use {
    'ray-x/cmp-treesitter', options = {
      get_bufnrs = function()
        local bufs = {}
        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
          if vim.api.nvim_buf_get_option(buf, 'buflisted') then
            bufs[buf] = true
          end
        end
        return vim.tbl_keys(bufs)
      end
    }
  }
```

 `cmp-treesitter` is hard-coded to collect candidates from only current buffer. This patch is aiming to fix the issue.