### PR TITLE
feat: Highlight kinds using their respective capture highlight group

### DIFF
--- a/lua/cmp_treesitter/init.lua
+++ b/lua/cmp_treesitter/init.lua
@@ -66,7 +66,12 @@ source.complete = function(self, params, callback)
             w = string.sub(w, 1, 25) .. '…'
           end
           local camel_cased_kind = word.kind:gsub("%.", " "):gsub("(%w)(%w*)", function(first, rest) return first:upper() .. rest:lower() end):gsub(" ", "")
-          table.insert(items, { label = w, insertText = word.word, dup = 0, cmp = { kind_text = camel_cased_kind }})
+          table.insert(items, {
+            label = w,
+            insertText = word.word,
+            dup = 0,
+            cmp = { kind_text = camel_cased_kind, kind_hl_group = '@' .. word.kind }
+          })
         end
       end
     end


### PR DESCRIPTION
Neovim creates highlight groups that correspond to Treesitter capture groups (See `:h treesitter-highlight-groups`). This change causes the "kind" in the cmp completion window to be highlighted appropriately.

As an example:

![image](https://github.com/ray-x/cmp-treesitter/assets/719733/3ed8460a-8cd0-4856-8974-16c1da49baca)